### PR TITLE
Make `update-rust-toolchain` also update `rust-version`

### DIFF
--- a/.github/workflows/update-rust-toolchain.yml
+++ b/.github/workflows/update-rust-toolchain.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Update rust-toolchain
         id: update-rust-toolchain
         run: |
-          version="$(rustc +stable -V | awk '{ print $2 }')"
+          version=$(rustc +stable -V | awk '{ print $2 }')
           msrv=$(awk -F . '{ print $1 "." $2 }' <<< "$version")
           cat > ./rust-toolchain <<< "$version"
           sed -i 's/^rust-version = "[^"]\+"$/rust-version = "'"$msrv"'"/g' Cargo.toml

--- a/.github/workflows/update-rust-toolchain.yml
+++ b/.github/workflows/update-rust-toolchain.yml
@@ -19,7 +19,9 @@ jobs:
         id: update-rust-toolchain
         run: |
           version="$(rustc +stable -V | awk '{ print $2 }')"
+          msrv=$(awk -F . '{ print $1 "." $2 }' <<< "$version")
           cat > ./rust-toolchain <<< "$version"
+          sed -i 's/^rust-version = "[^"]\+"$/rust-version = "'"$msrv"'"/g' Cargo.toml
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Create PR

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-extdeps"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.69"
 license = "MIT OR Apache-2.0"
 description = "A tool to help you manage external C/C++ dependencies"
 repository = "https://github.com/qryxip/cargo-extdeps"


### PR DESCRIPTION
- Make `update-rust-toolchain` also update `rust-version`
- chore: Remove unnecessary double-quoting
- Bump the MSRV
